### PR TITLE
added nyaa error handling and url check for proxy addr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,20 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >  - plex_debrid is currently only able to refresh your entire jellyfinlibrary. Partial library scans to come shortly!
 >
 ></details>
+>
+><details>
+>  <summary><b><u><img src="https://hotio.dev/webhook-avatars/overseerr.png" height="16"> Overseerr requests:</u></b></summary>
+> 
+>  - To mark your overserr requests as available after a succesful download, navigate to '/Settings/Library Service/Library update service/Edit/'
+>
+></details>
+>
+><details>
+>  <summary><b><u><img src="https://raw.githubusercontent.com/Fallenbagel/jellyseerr/main/public/android-chrome-512x512.png" height="16"> Jellyseerr requests:</u></b></summary>
+> 
+>  - To mark your jellyseerr requests as available after a succesful download, navigate to '/Settings/Library Service/Library update service/Edit/'
+>
+></details>
  
 ### :eyes: Library Ignore Services
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 ><details>
 >  <summary><b><u>Defining versions to download:</u></b></summary>
 >  
+>  - Check out the Wiki for a complete documentation of the version settings: https://github.com/itsToggle/plex_debrid/wiki/Version-Guides
 >  - You can define what release qualities plex_debrid should download by defining a "version". You can add an unlimited amount of versions by navigating to '/Settings/Scraper Settings/versions'. By default, plex_debrid only comes with 1 version definiton ([1080p SDR])
 >  - versions consist of an unlimited amount of completely customizable "rules" and "triggers". 
 >  - "Rules" define the quality requirements of your versions. The rules can be either formulated as a requirement or as a preference. The first rule has the highest priority, the last one the lowest. To give some examples, here are the rules that make up the default [1080p SDR] version:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This is a work in progress, and im not a professional programmer. shits not read
    - <img src="https://orionoid.com/web/images/logo/logo256.png" height="16"> **[Orionoid](https://orionoid.com/)**
    - <img src="https://progsoft.net/images/rarbg-icon-648af4dcc6ec63ee49d6c050af63d2547c74d46c.png" height="16"> **[RARBG](https://rarbg.to/)**
    - <img src="https://1337x.to/favicon.ico" height="16"> **[1337X](https://1337x.to/)**
+   - <img src="https://nyaa.si/static/favicon.png" height="16"> **[NYAA](https://nyaa.si/)**
 - Defining multiple, completely customizable versions to download (2160p HDR, 1080p SDR, etc)
 - Checking for cached releases and adding them to:
    - <img src="https://fcdn.real-debrid.com/0818/favicons/favicon.ico" height="16"> **[RealDebrid](http://real-debrid.com/?id=5708990)**
@@ -50,37 +51,44 @@ This is a work in progress, and im not a professional programmer. shits not read
    - <img src="https://app.plex.tv/desktop/favicon.ico" height="16"> **[Plex](https://plex.tv/)**
    - <img src="https://jellyfin.org/images/favicon.ico" height="16"> **[Jellyfin](https://jellyfin.org/)**
  
-### Community
+ 
+## Community
 
-Feel free to ask any questions on github [discussions](https://github.com/itsToggle/plex_debrid/discussions) or create a new [issue](https://github.com/itsToggle/plex_debrid/issues) if you find a bug or have an idea for an improvement.
+- Feel free to ask any questions on github [discussions](https://github.com/itsToggle/plex_debrid/discussions) 
+- or create a new [issue](https://github.com/itsToggle/plex_debrid/issues) if you find a bug or have an idea for an improvement.
 
-If github is not your cup of tee, join the plex_debrid [discord server](https://discord.gg/u3vTDGjeKE) or find me on [reddit](https://www.reddit.com/user/itsToggle)
+If github is not your cup of tea; 
+- join the plex_debrid [discord server](https://discord.gg/u3vTDGjeKE) 
+- or find me on [reddit](https://www.reddit.com/user/itsToggle)
+
  
 ## Setup:
 
-Aside from this general setup guide, here some step-by-step guides with specific examples for a few different operating systems:
+### :pushpin: Step by Step and VPS Guides:
 
-<details>
-  <summary><b><u>Step by Step for your OS:</u></b></summary>
-  
-  - **[Docker (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#docker-setup)**
-  - **[Windows (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#windows-setup)**
-  - **[Linux Server (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#linux-server-setup)**
-  - **[Linux ARM Server (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#linux-arm64-server-setup)**
-  - **[FreeBSD (u/TheNicestRichtofen)](https://www.reddit.com/r/Piracy/comments/v5zpj7/comment/ibnikqh/?utm_source=share&utm_medium=web2x&context=3)**
-  - **[Android](https://github.com/itsToggle/plex_debrid/tree/android)**
-  - **Rooted Nvidia Shield guide from user "b u n n y" up on discord**
-</details>
+*Aside from this general setup guide, here some step-by-step guides with specific examples for a few different operating systems. If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that some debrid services block such IP addresses from accessing their servers.*
 
-If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that some debrid services block such IP addresses from accessing their servers:
-<details>
-  <summary><b><u>Help for a VPS/Seedbox Setup</u></b></summary>
-  
-  - **I do not encourage you to disregard your debrid services code of conduct.**
-  - Debrid services like realdebrid block common VPS or Seedbox IP addresses. They do however have a list of whitelisted VPNs, behind which you can run your server. For realdebrid you can find this list on https://real-debrid.com/vpn . You can also use this address to check wether or not your servers IP is blocked by running the commands `curl -4 https://real-debrid.com/vpn | grep blocked` and `curl -6 https://real-debrid.com/vpn | grep blocked`. If you have the option, you can try to request a different IP address from your VPS provider, preferably your own personal IPv4 address which will most likely not be blocked.
-</details>
+><details>
+>  <summary><b><u>Step by Step for your OS:</u></b></summary>
+>  
+>  - **[Docker (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#docker-setup)**
+>  - **[Windows (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#windows-setup)**
+>  - **[Linux Server (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#linux-server-setup)**
+>  - **[Linux ARM Server (Wiki)](https://github.com/itsToggle/plex_debrid/wiki/Setup-Guides#linux-arm64-server-setup)**
+>  - **[FreeBSD (u/TheNicestRichtofen)](https://www.reddit.com/r/Piracy/comments/v5zpj7/comment/ibnikqh/?utm_source=share&utm_medium=web2x&context=3)**
+>  - **[Android](https://github.com/itsToggle/plex_debrid/tree/android)**
+>  - **Rooted Nvidia Shield guide from user "b u n n y" up on discord**
+></details>
+>
+><details>
+>  <summary><b><u>Help for a VPS/Seedbox Setup</u></b></summary>
+>  
+>  - **I do not encourage you to disregard your debrid services code of conduct.**
+>  - Debrid services like realdebrid block common VPS or Seedbox IP addresses. They do however have a list of whitelisted VPNs, behind which you can run your server. >For realdebrid you can find this list on https://real-debrid.com/vpn . You can also use this address to check wether or not your servers IP is blocked by running the >commands `curl -4 https://real-debrid.com/vpn | grep blocked` and `curl -6 https://real-debrid.com/vpn | grep blocked`. If you have the option, you can try to request >a different IP address from your VPS provider, preferably your own personal IPv4 address which will most likely not be blocked.
+></details>
+>
 
-
+ 
 ### 1) :open_file_folder: Mount your debrid services:
 
 *For this download automation to work, you need to mount at least one debrid service as a virtual drive. I highly recommend using RealDebrid, as this service will recieve updates and new features from plex_debrid first. Please keep in mind that most debrid services dont allow you to access their service from multiple IP addresses in parallel. This is not an issue if you have a Plex server running, since everything you stream through plex (from any location, no matter how many in parallel) is routed through your servers IP address. While you have your plex server running though, you should not download from your debrid service in any other way than through plex.*
@@ -91,9 +99,9 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >  
 >  Realdebrid has now implement support for WebDav, which makes it mountable with official rclone software.
 >  
->  I do still recomend using my fork, since realdebrids WebDav does not allow for torrent file deletion through rclone and they limit the amount of torrents displayed to 200. They do claim the torrent file deletion works with other webdav mount programs, but i have not been able to test this yet. It also seems that the official realdebrid webdav is still slower and more bandwidth heavy than my rclone fork, because mounting the webdav leads to frequent re-discovering of already downloaded content. 
+>  I do still recomend using my forked version of rclone thats written explicitly for realdebrid, since realdebrids WebDav does not allow for torrent file deletion through rclone and they limit the amount of torrents displayed to 200. They do claim the torrent file deletion works with other webdav mount programs, but i have not been able to test this yet. It also seems that the official realdebrid webdav is still slower and more bandwidth heavy than my rclone fork, because mounting the webdav leads to frequent re-discovering of already downloaded content. 
 >  
->  **Mounting with my fork:**
+>  **Mounting with my rclone fork:**
 >  
 >  1. Install my rclone fork: https://github.com/itsToggle/rclone_rd
 >  2. configure rclone by running the command 'rclone config' (could be './rclone config' and depending on your os, the filename could be './rclone-linux' or similar. If you get a permission denied error (linux & macos), run 'sudo chmod u+x rclone-linux', adjusted to the filename.)
@@ -191,6 +199,7 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >  *You can run rclone as a background service by adding the mounting tag '--no-console' (Windows) or '--deamon' (Linux, Mac, etc)*
 ></details>
 
+ 
 ### 2) :tv: Setup your personal media server:
 
 *To stream content from your newly mounted virtual drive, its recommended to set up a personal media server like plex, emby or jellyfin. These services allow you to stream your content from outside your local network. You will have the best expirience when using plex, since you dont need any 3rd party website to download new content - you can simply add new movies/shows to your watchlist from inside any plex client app, wait a few seconds and then watch it (see the gif above). If you prefer emby or jellyfin as your personal media server, the only way to add new content is via trakt and jellyseerr. A different approach is to use media players like Infuse to access the mounted files, which too relies on trakt to add new content.*
@@ -208,6 +217,7 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >  **Please keep your libraries metadata agent as the default Plex metadata agent**
 >  </details>
 
+ 
 ### 3) :page_facing_up: Setup plex_debrid:
 
 *The plex_debrid script can be run as a docker container (dockerized version) or by simply executing it with python 3 (standard version).*
@@ -510,6 +520,7 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >
 ></details>
 
+ 
 ## Buy me a beer/coffee? :)
 
 I've written this automation because it's a hell of a lot of fun and because I've wanted a setup like this for a while. The continuation of this project does **not**, in any way, depend on monetary contributions. If you do want to buy me a beer/coffee, feel free to use my real-debrid [affiliate link](http://real-debrid.com/?id=5708990) or send a virtual beverage via [PayPal](https://www.paypal.com/paypalme/oidulibbe) :)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is a work in progress, and im not a professional programmer. shits not read
 
 Feel free to ask any questions on github [discussions](https://github.com/itsToggle/plex_debrid/discussions) or create a new [issue](https://github.com/itsToggle/plex_debrid/issues) if you find a bug or have an idea for an improvement.
 
-If github is not your cup of tee, join the plex_debrid [discord server](https://discord.gg/UKkPeRdukx) or find me on [reddit](https://www.reddit.com/user/itsToggle)
+If github is not your cup of tee, join the plex_debrid [discord server](https://discord.gg/u3vTDGjeKE) or find me on [reddit](https://www.reddit.com/user/itsToggle)
  
 ## Setup:
 

--- a/README.md
+++ b/README.md
@@ -476,15 +476,17 @@ If you want to run plex_debrid on a VPS or Seedbox, please keep in mind that som
 >  - versions consist of an unlimited amount of completely customizable "rules" and "triggers". 
 >  - "Rules" define the quality requirements of your versions. The rules can be either formulated as a requirement or as a preference. The first rule has the highest priority, the last one the lowest. To give some examples, here are the rules that make up the default [1080p SDR] version:
 >      
->        1) cache status  requirement :   cached
->        2) resolution    requirement :       <=  1080
->        3) resolution    preference  :  highest
->        4) title         requirement :  exclude  (\.DV\.|3D|\.H?D?.?CAM\.)
->        5) title         requirement :  exclude  (\.HDR\.)
->        6) title         preference  :  include  (EXTENDED|REMASTERED)
->        7) size          preference  :   lowest
->        8) seeders       preference  :  highest
->        9) size          requirement :       >=  0.1
+>        1)  cache status  requirement :   cached
+>        2)  resolution    requirement :       <=  1080
+>        3)  resolution    preference  :  highest
+>        4)  title         requirement :  exclude  (H?D?.?CAM|H?D?.?TS)
+>        5)  title         requirement :  exclude  (3D)
+>        6)  title         requirement :  exclude  (DO?VI?)
+>        7)  title         requirement :  exclude  (HDR)
+>        8)  title         preference  :  include  (EXTENDED|REMASTERED)
+>        9)  size          preference  :   lowest
+>        10) seeders       preference  :  highest
+>        11) size          requirement :       >=  0.1
 >      
 >  - "Triggers" define when plex_debrid should look for a version. You can add triggers that limit a version to a specific media type, or to specific movies/shows. You can define how many times plex_debrid should attempt to download a version and how many attempts should be made with other versions, before a version is attempted to be downloaded. Other triggers can limit a version to a specific genre or can limit a version to a specific user that requested the movie/show. Here are some of the possible triggers, given in an example of a 720p version that should only be looked for, if the media items in question are "shows" that have been released "before 2010", are not "Family Guy" or "Last week tonight", and no other version has been found for "5 attempts":
 >      

--- a/scraper/services/nyaa.py
+++ b/scraper/services/nyaa.py
@@ -37,7 +37,9 @@ def scrape(query, altquery):
             ui_print("[nyaa] using extended query: " + query,ui_settings.debug)
         if proxy == "":
             proxy = "nyaa.si"
-        url = 'https://' + proxy + '/?f=0' + params + '&q=' + str(query) 
+            url = 'https://' + proxy + '/?f=0' + params + '&q=' + str(query) 
+        elif proxy.startswith("http://") or proxy.startswith("https://"):
+            url = proxy + '/?f=0' + params + '&q=' + str(query)
         response = None
         try:
             response = get(url)
@@ -87,7 +89,11 @@ def scrape(query, altquery):
                     soup = BeautifulSoup(response.content, 'html.parser')
         except Exception as e:
             if hasattr(response,"status_code") and not str(response.status_code).startswith("2"):
-                ui_print('nyaa error '+str(response.status_code)+': 1337x is temporarily not reachable')
+                ui_print('nyaa error '+str(response.status_code)+': nyaa is temporarily not reachable')
+            elif session.get(url).status_code == 200:
+                ui_print('nyaa error: proxy unable to be scraped. please choose another proxy.')
+            elif session.get(url).status_code == 429:
+                ui_print('nyaa error: too many requests. nyaa.si is blocking your ip. please use a proxy.')
             else:
                 ui_print('nyaa error: unknown error')
             response = None


### PR DESCRIPTION
As discussed in discord, everything tested and works perfectly. If there's issues further, I'll be happy to maintain any of my code.

This checks for the "http://" or "https://" in the proxy address that users provide. People sometimes just copy/paste addresses from the browser which brings over that https part. This will account for that now.

Also added error handling to determine if a page can be scraped or not (200 on a proxy but BeautifulSoup still unable to scrape) or for an error 429 which means the user was banned from the original proxy of "nyaa.si".

Let me know if changes need to be made.