### PR TITLE
Fix issue 578 (recurrence of #478): Single Episode Downloads Not Functioning Correctly

### DIFF
--- a/content/classes.py
+++ b/content/classes.py
@@ -1366,7 +1366,7 @@ class media:
             if len(self.Episodes) > 2:
                 if self.season_pack(scraped_releases):
                     debrid_downloaded, retry = self.debrid_download()
-                    # if scraper.traditional() or debrid_downloaded:
+                if scraper.traditional() or debrid_downloaded:
                     for episode in self.Episodes:
                         episode.skip_scraping = True
                 # If there was nothing downloaded, scrape specifically for this season


### PR DESCRIPTION
It looks like this line was accidentally commented out as part of [this commit](https://github.com/itsToggle/plex_debrid/commit/244e5fc5) which resulted in ``episode.skip_scraping = True`` always being set regardless of whether a season pack was downloaded. This disabled any episode level scraping further down the line...

See https://github.com/itsToggle/plex_debrid/issues/578