### PR TITLE
Add plex server address help

### DIFF
--- a/content/services/plex.py
+++ b/content/services/plex.py
@@ -791,8 +791,8 @@ class library(classes.library):
                     types = ['1'] if Directory.type == "movie" else  ['2', '3', '4']
                     sections += [[Directory.key,types]]
                     names += [Directory.title]
-        except:
-            ui_print("[plex error]: couldnt reach local plex server at: " + library.url + " to determine library sections. Make sure the address is correct, the server is running, and youve set up at least one library.")
+        except Exception as e:
+            ui_print("[plex error]: couldnt reach local plex server at: " + library.url + " to determine library sections. Make sure the address is correct, the server is running, and youve set up at least one library. Error:" + e)
         if len(sections) == 0:
             return list_
         if not silent:
@@ -876,11 +876,11 @@ class library(classes.library):
                             episode.grandparentEID = item.EID
             except:
                 ui_print('done')
-                ui_print("[plex error]: found incorrectly matched library item : " + item.title + " - this item needs a metadata refresh (open plex webui, find item, open item menu, refresh metadata).")  
+                ui_print("[plex error]: found incorrectly matched library item : " + item.title + " - this item needs a metadata refresh (open plex webui, find item, open item menu, refresh metadata).")
         ui_print('done')
         current_library = copy.deepcopy(list_)
         if first_load and updated:
-            store.save(current_library,"plex","metadata")       
+            store.save(current_library,"plex","metadata")
         return list_
 
 def search(query, library=[]):

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -348,9 +348,9 @@ settings_list = [
         setting('Trakt library user', [''], content.services.trakt.library, 'user', hidden=True),
         setting('Trakt refresh user', [''], content.services.trakt.library.refresh, 'user', hidden=True),
         setting('Plex library refresh', [''], content.services.plex.library.refresh, 'sections', hidden=True,moveable=False),
-        setting('Plex library partial scan', 'Please enter "true" or "false": ', content.services.plex.library.refresh, 'partial', hidden=True, help="Specify wether or not plex_debrid should attempt to partially scan your plex libraries."),
+        setting('Plex library partial scan', 'Please enter "true" or "false": ', content.services.plex.library.refresh, 'partial', hidden=True, help="Specify whether or not plex_debrid should attempt to partially scan your plex libraries."),
         setting('Plex library refresh delay', 'Please enter a number (e.g 420 or 69.69): ', content.services.plex.library.refresh, 'delay', hidden=True, help="Specify the amount of seconds plex_debrid should wait between adding a torrent and scanning your plex libraries."),
-        setting('Plex server address', 'Please enter your Plex server address: ', content.services.plex.library, 'url', hidden=True),
+        setting('Plex server address', 'Please enter your Plex server address: ', content.services.plex.library, 'url', hidden=True, help="It must include protocol (eg. http) and not include anything trailing slashes. eg. http://my-plex-server:32400"),
         setting('Plex library check', [
             'Please specify a library section number that should be checked for existing content before download: '],
                 content.services.plex.library, 'check', hidden=True, entry="section",


### PR DESCRIPTION
I had an issue with the plex server url which was hard to pinpoint.
- Add exception to the error message to help debug errors
- Add help message for the expected url format
  - Plex doesn't like extra trailing slashes in the url.
  - requests requires the protocol to be present